### PR TITLE
Add UT Austin to SRS & HRT coverage list

### DIFF
--- a/0001_Education/Oversea/In_US/可以报销HRT&SRS的美国大学的清单.md
+++ b/0001_Education/Oversea/In_US/可以报销HRT&SRS的美国大学的清单.md
@@ -70,6 +70,7 @@ University of Oregon   <br>
 University of Pennsylvania   <br>
 University of Rochester   <br>
 University of Southern California   <br>
+University of Texas at Austin   <br>
 University of Vermont   <br>
 University of Washington   <br>
 University of Wisconsin, Madison (SRS only, without HRT, information provide by Gemma(UWM))(仅SRS，HRT不报销，消息来自Gemma(UWM)) <br> 


### PR DESCRIPTION
UT Austin (both faculty and student polity) is under BCBSTX PPO plan.

不过考虑申请的同学还是推荐考虑一下红州影响，尤其是未成年的。

